### PR TITLE
Issue #12: aws-https: Missing production dependency requirements

### DIFF
--- a/aws-https/package-lock.json
+++ b/aws-https/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@sailplane/aws-https",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -521,9 +521,9 @@
       "dev": true
     },
     "aws-sdk": {
-      "version": "2.401.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.401.0.tgz",
-      "integrity": "sha512-mOI4gzKoP/g8Q0ToAaqTh7TijGG9PvGVVUkKmurXqBKy7GTPmy4JizfVkTrM+iBg7RAsx5H2lBxBFpdEFBa5fg==",
+      "version": "2.503.0",
+      "resolved": "https://npm.wdprapps.disney.com/aws-sdk/-/aws-sdk-2.503.0.tgz",
+      "integrity": "sha512-DPwRxhPYCGNvKL9rUhpAoOVpMRyISbVMlXykLQknYo7wyOI+jYcyA7t8H7IFPAqj4ZG+R+Au9tO/KT4im+2gbg==",
       "dev": true,
       "requires": {
         "buffer": "4.9.1",
@@ -546,8 +546,7 @@
     "aws4": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
-      "dev": true
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
     },
     "babel-code-frame": {
       "version": "6.26.0",
@@ -850,7 +849,7 @@
     },
     "base64-js": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+      "resolved": "https://npm.wdprapps.disney.com/base64-js/-/base64-js-1.3.0.tgz",
       "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
       "dev": true
     },
@@ -933,7 +932,7 @@
     },
     "buffer": {
       "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "resolved": "https://npm.wdprapps.disney.com/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
       "dev": true,
       "requires": {
@@ -1502,7 +1501,7 @@
     },
     "events": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "resolved": "https://npm.wdprapps.disney.com/events/-/events-1.1.1.tgz",
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
       "dev": true
     },
@@ -2533,7 +2532,7 @@
     },
     "ieee754": {
       "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+      "resolved": "https://npm.wdprapps.disney.com/ieee754/-/ieee754-1.1.8.tgz",
       "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q=",
       "dev": true
     },
@@ -3346,7 +3345,7 @@
     },
     "jmespath": {
       "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "resolved": "https://npm.wdprapps.disney.com/jmespath/-/jmespath-0.15.0.tgz",
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
       "dev": true
     },
@@ -4282,7 +4281,7 @@
     },
     "punycode": {
       "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "resolved": "https://npm.wdprapps.disney.com/punycode/-/punycode-1.3.2.tgz",
       "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=",
       "dev": true
     },
@@ -4294,7 +4293,7 @@
     },
     "querystring": {
       "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "resolved": "https://npm.wdprapps.disney.com/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
       "dev": true
     },
@@ -4892,7 +4891,7 @@
     },
     "sax": {
       "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "resolved": "https://npm.wdprapps.disney.com/sax/-/sax-1.2.1.tgz",
       "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
       "dev": true
     },
@@ -5662,7 +5661,7 @@
     },
     "url": {
       "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "resolved": "https://npm.wdprapps.disney.com/url/-/url-0.10.3.tgz",
       "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
       "dev": true,
       "requires": {
@@ -5883,7 +5882,7 @@
     },
     "xml2js": {
       "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "resolved": "https://npm.wdprapps.disney.com/xml2js/-/xml2js-0.4.19.tgz",
       "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "dev": true,
       "requires": {
@@ -5893,7 +5892,7 @@
     },
     "xmlbuilder": {
       "version": "9.0.7",
-      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "resolved": "https://npm.wdprapps.disney.com/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
       "dev": true
     },

--- a/aws-https/package.json
+++ b/aws-https/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sailplane/aws-https",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "HTTPS client with AWS Signature v4",
   "keywords": [
     "aws",
@@ -30,7 +30,6 @@
     "@types/jest": "23.3.13",
     "@types/node": "^8.10.10",
     "aws-sdk": "^2.358.0",
-    "aws4": "^1.8.0",
     "jest": "^23.6.0",
     "nock": "^10.0.2",
     "ts-jest": "^23.10.2",
@@ -39,7 +38,11 @@
     "typescript": "^2.9.2"
   },
   "peerDependencies": {
-    "@sailplane/logger": "^1.0.0"
+    "@sailplane/logger": "^1.0.0",
+    "aws-sdk": "^2.358.0"
+  },
+  "dependencies": {
+    "aws4": "^1.8.0"
   },
   "main": "dist/aws-https.js",
   "files": [

--- a/elasticsearch-client/package-lock.json
+++ b/elasticsearch-client/package-lock.json
@@ -34,7 +34,10 @@
     },
     "@sailplane/aws-https": {
       "version": "file:../aws-https",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "aws4": "^1.8.0"
+      }
     },
     "@sailplane/logger": {
       "version": "file:../logger",


### PR DESCRIPTION
Made aws-sdk into a peer dependency and aws4 into a full dependency.

Any project already using aws-https doesn't need this change, it simply serves to:

- Automatically pull in aws4, so those using this package don't need to on their own.
- Nag user of this package if they don't have aws-sdk, which is required but we want to let the user choose their version.

PR includes patch version bump.
