### PR TITLE
Issue #33 Failure to authenticate with Fargate Task Role after about 8 hours

### DIFF
--- a/aws-https/lib/aws-https-with-aws.test.ts
+++ b/aws-https/lib/aws-https-with-aws.test.ts
@@ -27,6 +27,7 @@ describe('AwsHttps with AWS', () => {
             .post('/test', body)
             .reply(200, response);
         const sut = new AwsHttps(true);
+        expect(AwsHttps['credentialsPromise']).toBeUndefined();
 
         // WHEN
         const reply = await sut.request({
@@ -42,6 +43,12 @@ describe('AwsHttps with AWS', () => {
         // THEN
         expect(reply).toEqual(response);
         expect(scope.isDone()).toBeTruthy();
-    });
+        expect(AwsHttps['credentialsPromise']).toBeTruthy();
 
+        // TEST refresh credentials
+        const sutReusingCreds = new AwsHttps();
+        expect(AwsHttps['credentialsPromise']).toBeDefined();
+        const sutRefreshingCreds = new AwsHttps(false, true);
+        expect(AwsHttps['credentialsPromise']).toBeUndefined();
+    });
 });


### PR DESCRIPTION
Added option to refresh credentials in the AwsHttps constructor.
Not needed in Lambdas, but longer running containers might rotate credentials.

See https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/Config.html#getCredentials-property

Resolves issue #33
Reported by @iursinoliveperson 
