### PR TITLE
Enhancement for issue #39 Provide credentials to AwsHttps

### DIFF
--- a/aws-https/lib/aws-https-with-aws.test.ts
+++ b/aws-https/lib/aws-https-with-aws.test.ts
@@ -10,45 +10,128 @@ describe('AwsHttps with AWS', () => {
     const serverHostname = 'example.com';
     const serverUrl = 'https://' + serverHostname;
 
-    afterAll(() => {
+    afterEach(() => {
         nock.cleanAll();
     });
 
-    test('request(POST /test body sigv4)', async () => {
-        // // GIVEN
-        const body = JSON.stringify({ cursor: 3, map: "Irvine"});
-        const response = { success: true };
-        const scope = nock(serverUrl, {
+    describe('with provided AWS credentials', () => {
+        test('does a signed POST', async () => {
+            // // GIVEN
+            const awsCredentials = {
+                accessKeyId: 'ACCESS-KEY-ID',
+                secretAccessKey: 'SECRET-ACCESS-KEY',
+                sessionToken: 'SESSION-TOKEN'
+            };
+
+            const body = JSON.stringify({ cursor: 3, map: "Irvine"});
+            const response = { success: true };
+            const scope = nock(serverUrl, {
                 reqheaders: {
                     "X-Amz-Date": /20......T......Z/,
-                    "Authorization": /AWS4-HMAC-SHA256 Credential=deadbeaf.*, SignedHeaders=content-length;content-type;host;x-amz-date, Signature=.*/
+                    "Authorization": /AWS4-HMAC-SHA256 Credential=ACCESS-KEY-ID.*, SignedHeaders=content-length;content-type;host;x-amz-date;x-amz-security-token, Signature=.*/
                 }
             })
-            .post('/test', body)
-            .reply(200, response);
-        const sut = new AwsHttps(true);
-        expect(AwsHttps['credentialsPromise']).toBeUndefined();
+                .post('/test', body)
+                .reply(200, response);
+            const sut = new AwsHttps(true, awsCredentials);
+            expect(AwsHttps['credentialsInitializedPromise']).toBeUndefined();
+            expect(sut['awsCredentials']).toBe(awsCredentials);
 
-        // WHEN
-        const reply = await sut.request({
+            // WHEN
+            const reply = await sut.request({
+                protocol: 'https:',
+                method: 'POST',
+                hostname: serverHostname,
+                path: '/test',
+                body: body,
+                awsSign: true,
+                headers: { 'Content-Type': 'application/json' }
+            });
+
+            // THEN
+            expect(reply).toEqual(response);
+            expect(scope.isDone()).toBeTruthy();
+            expect(AwsHttps['credentialsInitializedPromise']).toBeUndefined();
+            expect(sut['awsCredentials']).toBe(awsCredentials);
+        });
+    });
+
+    describe('with process AWS credentials', () => {
+        const body = JSON.stringify({cursor: 3, map: "Irvine"});
+        const requestOptions = {
             protocol: 'https:',
             method: 'POST',
             hostname: serverHostname,
             path: '/test',
             body: body,
             awsSign: true,
-            headers: { 'Content-Type': 'application/json' }
+            headers: {'Content-Type': 'application/json'}
+        };
+        const response = {success: true};
+        let scope;
+
+        beforeEach(() => {
+            scope = nock(serverUrl, {
+                reqheaders: {
+                    "X-Amz-Date": /20......T......Z/,
+                    "Authorization": /AWS4-HMAC-SHA256 Credential=deadbeaf.*, SignedHeaders=content-length;content-type;host;x-amz-date, Signature=.*/
+                }
+            }).post('/test', body)
+              .reply(200, response);
         });
 
-        // THEN
-        expect(reply).toEqual(response);
-        expect(scope.isDone()).toBeTruthy();
-        expect(AwsHttps['credentialsPromise']).toBeTruthy();
+        test('does first signed POST', async () => {
+            // // GIVEN
+            const sut = new AwsHttps(true);
+            expect(AwsHttps['credentialsInitializedPromise']).toBeUndefined();
+            expect(sut['awsCredentials']).toBeUndefined();
 
-        // TEST refresh credentials
-        const sutReusingCreds = new AwsHttps();
-        expect(AwsHttps['credentialsPromise']).toBeDefined();
-        const sutRefreshingCreds = new AwsHttps(false, true);
-        expect(AwsHttps['credentialsPromise']).toBeUndefined();
+            // WHEN
+            const reply = await sut.request(requestOptions);
+
+            // THEN
+            expect(reply).toEqual(response);
+            expect(scope.isDone()).toBeTruthy();
+            expect(AwsHttps['credentialsInitializedPromise']).toBeTruthy();
+            expect(sut['awsCredentials']).toBeDefined();
+        });
+
+        test('does another signed POST; reuse creds', async () => {
+            // // GIVEN
+            const sut = new AwsHttps(true);
+            expect(AwsHttps['credentialsInitializedPromise']).toBeDefined();
+            expect(sut['awsCredentials']).toBeUndefined();
+
+            // WHEN
+            const reply = await sut.request(requestOptions);
+
+            // THEN
+            expect(reply).toEqual(response);
+            expect(scope.isDone()).toBeTruthy();
+            expect(AwsHttps['credentialsInitializedPromise']).toBeTruthy();
+            expect(sut['awsCredentials']).toBeDefined();
+        });
+
+        test('resets credentials', async () => {
+            const sut = new AwsHttps(false, true);
+            expect(AwsHttps['credentialsInitializedPromise']).toBeUndefined();
+            expect(sut['awsCredentials']).toBeUndefined();
+        });
+
+        test('after reset, again do signed POST', async () => {
+            // // GIVEN
+            const sut = new AwsHttps(true);
+            expect(AwsHttps['credentialsInitializedPromise']).toBeUndefined();
+            expect(sut['awsCredentials']).toBeUndefined();
+
+            // WHEN
+            const reply = await sut.request(requestOptions);
+
+            // THEN
+            expect(reply).toEqual(response);
+            expect(scope.isDone()).toBeTruthy();
+            expect(AwsHttps['credentialsInitializedPromise']).toBeTruthy();
+            expect(sut['awsCredentials']).toBeDefined();
+        });
     });
 });

--- a/aws-https/lib/aws-https.ts
+++ b/aws-https/lib/aws-https.ts
@@ -20,24 +20,40 @@ export type AwsHttpsOptions = https.RequestOptions & {
     awsSign?: boolean
 };
 
+export type AwsCredentials = AWS.Credentials | {
+    accessKeyId: string
+    secretAccessKey: string
+    sessionToken?: string
+}
+
 /**
  * Light-weight utility for making HTTPS requests in AWS environments.
  */
 export class AwsHttps {
     /** Resolves when credentials are available - shared by all instances */
-    private static credentialsPromise: Promise<void>|undefined = undefined;
+    private static credentialsInitializedPromise: Promise<void>|undefined = undefined;
+
+    /** Credentials to use in this instance */
+    private awsCredentials?: AwsCredentials = undefined;
 
     /**
      * Constructor.
      * @param verbose true to log everything, false for silence,
      *                undefined (default) for normal logging.
-     * @param refreshCredentials if `true` obtain fresh AWS credentials before signing
-     *            a new request. Otherwise, previous credentials may be reused. Not
-     *            needed in Lambdas, but longer running containers may rotate credentials.
+     * @param credentials
+     *      If not defined, credentials will be obtained by default SDK behavior for the runtime environment.
+     *                      This happens once and then is cached; good for Lambdas.
+     *      If `true`, clear cached to obtain fresh credentials from SDK.
+     *                 Good for longer running containers that rotate credentials.
+     *      If an object with accessKeyId, secretAccessKey, and sessionToken
+     *                 use these credentials for this instance
      */
-    constructor(private readonly verbose?: boolean, refreshCredentials = false) {
-        if (refreshCredentials) {
-            AwsHttps.credentialsPromise = undefined;
+    constructor(private readonly verbose?: boolean, credentials?: boolean | AwsCredentials) {
+        if (credentials) {
+            AwsHttps.credentialsInitializedPromise = undefined;
+            if (typeof credentials === 'object' && credentials.accessKeyId) {
+                this.awsCredentials = credentials;
+            }
         }
     }
 
@@ -147,30 +163,32 @@ export class AwsHttps {
      * @return signed version of the request.
      */
     private async awsSign(request: AwsHttpsOptions): Promise<AwsHttpsOptions> {
-        if (!AwsHttps.credentialsPromise) {
-            // Prepare AWS credentials
-            AwsHttps.credentialsPromise = new Promise((resolve, reject) => {
-                AWS.config.getCredentials((err) => {
-                    if (err) {
-                        logger.error("Unable to load AWS credentials", err);
-                        reject(err);
-                    }
-                    else {
-                        resolve();
-                    }
+        if (!this.awsCredentials) {
+            if (!AwsHttps.credentialsInitializedPromise) {
+                // Prepare process-wide AWS credentials
+                AwsHttps.credentialsInitializedPromise = new Promise((resolve, reject) => {
+                    AWS.config.getCredentials((err) => {
+                        if (err) {
+                            logger.error("Unable to load AWS credentials", err);
+                            reject(err);
+                        }
+                        else {
+                            resolve();
+                        }
+                    });
                 });
-            });
+            }
+
+            // Wait for process-wide AWS credentials to be available
+            await AwsHttps.credentialsInitializedPromise;
+            this.awsCredentials = AWS.config.credentials!;
         }
 
-        // Wait for AWS credentials to be available
-        await AwsHttps.credentialsPromise;
-
         // Sign the request
-        const c = AWS.config.credentials!;
         const signCreds = {
-            accessKeyId: c.accessKeyId,
-            secretAccessKey: c.secretAccessKey,
-            sessionToken: c.sessionToken
+            accessKeyId: this.awsCredentials.accessKeyId,
+            secretAccessKey: this.awsCredentials.secretAccessKey,
+            sessionToken: this.awsCredentials.sessionToken
         };
         return aws4.sign(request, signCreds);
     }

--- a/aws-https/lib/aws-https.ts
+++ b/aws-https/lib/aws-https.ts
@@ -45,8 +45,8 @@ export class AwsHttps {
      *                      This happens once and then is cached; good for Lambdas.
      *      If `true`, clear cached to obtain fresh credentials from SDK.
      *                 Good for longer running containers that rotate credentials.
-     *      If an object with accessKeyId, secretAccessKey, and sessionToken
-     *                 use these credentials for this instance
+     *      If an object with accessKeyId, secretAccessKey, and sessionToken,
+     *                 use these credentials for this instance.
      */
     constructor(private readonly verbose?: boolean, credentials?: boolean | AwsCredentials) {
         if (credentials) {

--- a/docs/source/aws_https.rst
+++ b/docs/source/aws_https.rst
@@ -41,7 +41,7 @@ Simple example to GET from URL:
     const ping = await http.request(options);
 
 
-Example hitting API with IAM credentials:
+Example hitting API with the container's AWS credentials:
 
 .. code-block:: ts
 
@@ -77,6 +77,28 @@ Example hitting API with IAM credentials:
             throw err;
         }
     }
+
+Example hitting API with the custom AWS credentials:
+
+.. code-block:: ts
+
+    // Call my helper function to get credentials with AWS.STS
+    const roleCredentials = await this.getAssumeRoleCredentials();
+
+    const awsCredentials = {
+        accessKey: roleCredentials.AccessKeyId,
+        secretKey: roleCredentials.SecretAccessKey,
+        sessionToken: roleCredentials.SessionToken,
+    };
+    const http = new AwsHttps(false, awsCredentials);
+
+    // Build request options from a method and URL
+    const url = new URL('https://www.onica.com/ping.json');
+    const options = http.buildOptions('GET' url);
+
+    // Make request and parse JSON response.
+    const ping = await http.request(options);
+
 
 The :doc:`elasticsearch_client` package is a simple example using AwsHttps.
 


### PR DESCRIPTION
- Enhanced AwsHttps to accept AWS.Credentials to use
- Added example for providing credentials to the AwsHttps documentation
- Added/enhanced unit tests for AwsHttps

Implements changes for issue #39 .

@iursinoliveperson , please try this out. The unit tests exercise it, but not in a real AWS account. The easy way to test it is to just pull a copy of this modified `aws-https/lib/aws-https.ts` into your project. Since I can't make you a reviewer, please comment with your results.
