### PR TITLE
Fix for issue #40 - better detection of Lambda service vs offline

### DIFF
--- a/docs/source/logger.rst
+++ b/docs/source/logger.rst
@@ -58,6 +58,19 @@ The output of Logger varies based on some global settings, whether the Lambda is
 in AWS or local (serverless-offline, SAM offline), and whether the runtime is Node.js 10 vs
 earlier versions.
 
+Default behavior should work for Lambdas. If you are using Logger in another container (EC2, Fargate, ...)
+you likely will want to adjust these settings.
+
+CloudWatch detection
+--------------------
+
+The default behaviors of some configuration change depending on whether log output is going
+to CloudWatch vs local console. This is because within the AWS Lambda service, logging to
+stdout is automatically prefixed with the log level and times stamp. Local console does not
+So Logger adds these for you when a login shell (offline mode) is detected. You can force
+
+Override from environment variable ``export LOG_TO_CLOUDWATCH=true`` or ``export LOG_TO_CLOUDWATCH=false``
+
 globalLogLevel
 --------------
 
@@ -78,6 +91,8 @@ and outputLevels is set to false.
 
 Override programmatically: ``Logger.outputLevels = false;``
 
+Override from environment variable ``export LOG_TO_CLOUDWATCH=true`` or ``export LOG_TO_CLOUDWATCH=false``
+
 logTimestamps
 -------------
 Output date & time prefix on logged lines?
@@ -86,12 +101,18 @@ Timestamps are enabled outside of AWS Lambda, and disabled in AWS Lambda where C
 
 Override programmatically: ``Logger.logTimestamps = false;``
 
+Override from environment variable: ``export LOG_TIMESTAMPS=true``
+
 formatObjects
 -------------
 If true, objects logged by debugObject(), infoObject(), warnObject() and errorObject() will be formatted with
 proper indentation. If false, no formatting is performed.
 
 Formatting is enabled outside of AWS Lambda, and disabled in AWS Lambda where CloudWatch provides formatting.
+
+Override programmatically: ``Logger.formatObjects = false;``
+
+Override from environment variable: ``export LOG_FORMAT_OBJECTS=true``
 
 Type Declarations
 ^^^^^^^^^^^^^^^^^

--- a/injector/example/package.json
+++ b/injector/example/package.json
@@ -3,22 +3,22 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "start": "sls offline start"
+    "start": "sls offline start --printOutput"
   },
   "devDependencies": {
-    "serverless-offline": "^5.12.0",
+    "serverless-offline": "^6.1.4",
     "serverless-webpack": "^5.2.0",
-    "ts-loader": "^6.2.1",
-    "ts-node": "^8.5.2",
-    "typescript": "^3.7.2",
-    "webpack": "^4.41.2",
-    "webpack-cli": "^3.3.10"
+    "ts-loader": "^6.2.2",
+    "ts-node": "^8.8.2",
+    "typescript": "^3.8.3",
+    "webpack": "^4.42.1",
+    "webpack-cli": "^3.3.11"
   },
   "dependencies": {
     "@sailplane/injector": "^1.0.1",
     "@sailplane/lambda-utils": "^2.0.0",
-    "@sailplane/logger": "^2.0.0",
-    "aws-sdk": "^2.580.0",
+    "@sailplane/logger": "file:../../logger",
+    "aws-sdk": "^2.654.0",
     "bottlejs": "^1.7.2",
     "middy": "^0.30.5"
   }

--- a/logger/lib/logger.ts
+++ b/logger/lib/logger.ts
@@ -11,8 +11,9 @@ const LogLevelsMap = {
     'DEBUG': LogLevels.DEBUG
 };
 
-// Detect Lambda streaming to CloudWatch
-const IsCloudWatch = !!process.env.AWS_LAMBDA_LOG_GROUP_NAME;
+// If not running in an interactive shell (such is the case for AWS Lambda environment)
+// or the LOG_TO_CLOUDWATCH environment is set, then format output for CloudWatch.
+const IsCloudWatch = process.env.LOG_TO_CLOUDWATCH ? process.env.LOG_TO_CLOUDWATCH === 'true' : !process.env.SHELL;
 
 // Is Node.js version anything older than v10?
 const IsOldNode = process.version.match(/^v[0-9]\./) != null;


### PR DESCRIPTION
- Fix for issue #40: Logger not formatting correctly with serverless-offline 6.x
- Detect based on SHELL environment variable, which indicates an interactive user (offline) vs Lambda service
- Added explicit override with LOG_TO_CLOUDWATCH environment variable
- Updated injector/example to use serverless-offline v6 and test Logger.
- Added new documentation for these new configuration options, and added missing documentation for other options.