### PR TITLE
Issue #40 - Type error in LambdaUtils and in example

### DIFF
--- a/docs/source/lambda_utils.rst
+++ b/docs/source/lambda_utils.rst
@@ -72,7 +72,7 @@ General use
     export const hello = LambdaUtils.wrapApiHandler(async (event: LambdaUtils.APIGatewayProxyEvent) => {
         // These event objects are now always defined, so don't need to check for undefined. 🙂
         const who = event.pathParameters.who;
-        const points = parseInt(event.queryStringParameters.points || 0);
+        let points = Number(event.queryStringParameters.points || '0');
 
         if (points > 0) {
             let message = 'Hello ' + who;

--- a/lambda-utils/lib/lambda-utils.ts
+++ b/lambda-utils/lib/lambda-utils.ts
@@ -10,9 +10,6 @@ import {Logger} from "@sailplane/logger";
 
 const logger = new Logger('lambda-utils');
 
-/** Define the async version of ProxyHandler */
-export type AsyncProxyHandler = (event: APIGatewayEvent, context: Context) => Promise<any>;
-
 /**
  * Casted interface for APIGatewayProxyEvents as converted through the middleware
  */
@@ -32,6 +29,9 @@ export interface APIGatewayProxyEvent extends AWS_APIGatewayProxyEvent {
      */
     queryStringParameters: { [name: string]: string };
 }
+
+/** Define the async version of ProxyHandler */
+export type AsyncProxyHandler = (event: APIGatewayProxyEvent, context: Context) => Promise<any>;
 
 /**
  * Middleware to handle any otherwise unhandled exception by logging it and generating


### PR DESCRIPTION
- The APIGatewayEvent type is deprecated and replaced with APIGatewayProxyEvent
- Update AsyncProxyHandler to expect the new LambdaUtils version of APIGatewayProxyEvent.
- Fix bugs in documentation's example for LambdaUtils