### PR TITLE
Issue #64 fix setting LOG_LEVEL="NONE"

### DIFF
--- a/logger/lib/logger.test.ts
+++ b/logger/lib/logger.test.ts
@@ -1,6 +1,7 @@
-import {Logger, LogLevels} from "./logger";
+import { LogLevels } from './logger';
 
 describe('Logger', () => {
+    let Logger;
     let originalConsoleLog;
     let mockLog: jest.Mock;
     let mockDebug: jest.Mock;
@@ -9,6 +10,7 @@ describe('Logger', () => {
     let mockError: jest.Mock;
 
     beforeEach(() => {
+        Logger = require('./logger').Logger;
         originalConsoleLog = global.console.log;
         global.console.log = mockLog = jest.fn();
         global.console.debug = mockDebug = jest.fn();
@@ -20,6 +22,20 @@ describe('Logger', () => {
     afterEach(() => {
         global.console.log = originalConsoleLog;
         mockLog = undefined as any;
+    });
+
+    describe('globalLogLevel', () => {
+        test('set to "NONE" with environment variable', () => {
+            // GIVEN
+            process.env.LOG_LEVEL = 'NONE';
+            jest.resetModules();
+
+            // WHEN
+            Logger = require('./logger').Logger;
+
+            // THEN
+            expect(Logger.globalLogLevel).toBe(1);
+        });
     });
 
     describe('configured for AWS CloudWatch environment', () => {

--- a/logger/lib/logger.ts
+++ b/logger/lib/logger.ts
@@ -1,6 +1,6 @@
 
 export enum LogLevels {
-    NONE, ERROR, WARN, INFO, DEBUG
+    NONE = 1, ERROR, WARN, INFO, DEBUG
 }
 
 const LogLevelsMap = {
@@ -34,7 +34,7 @@ export class Logger {
      * Global logging level.
      * May be initialized via LOG_LEVEL environment variable, or set by code.
      */
-    static globalLogLevel: LogLevels = LogLevelsMap[process.env.LOG_LEVEL||'DEBUG'] || LogLevels.DEBUG;
+    static globalLogLevel: LogLevels = LogLevelsMap[process.env.LOG_LEVEL || 'DEBUG'] || LogLevels.DEBUG;
 
     /**
      * Include the level in log output?

--- a/logger/package-lock.json
+++ b/logger/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@sailplane/logger",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/logger/package.json
+++ b/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sailplane/logger",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "CloudWatch and serverless-offline friendly logger.",
   "keywords": [
     "aws",


### PR DESCRIPTION
Changes how the `globalLogLevel` static variable is set with the `LOG_LEVEL` environment variable so that a valid value of `NONE`, that would resolve to `0` is set instead of being treated as a falsy value and having the `DEBUG` default level set.