### PR TITLE
Update all Typescript to v3.8.x

### DIFF
--- a/expiring-value/package-lock.json
+++ b/expiring-value/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@sailplane/expiring-value",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -443,6 +443,21 @@
         "minimist": "^1.2.0"
       }
     },
+    "@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "dev": true
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.6.1.tgz",
+      "integrity": "sha512-DX3Z+T5dt1ockmPdobJS/FAsQPW4V4SrWEhD2iYQT2Cb2tQsiMnYxrcUH9By/Z3B+v0S5LMBkQtV/XOBbpLEOg==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -697,9 +712,9 @@
       "dev": true
     },
     "@tsconfig/node16": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.1.tgz",
-      "integrity": "sha512-FTgBI767POY/lKNDNbIzgAX6miIDBs6NTCbdlDb8TrWovHsSvaVIZDlTqym29C6UqhzwcJx4CYr+AlrMywA0cA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
     "@types/babel__core": {
@@ -787,9 +802,9 @@
       }
     },
     "@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "version": "12.20.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.19.tgz",
+      "integrity": "sha512-niAuZrwrjKck4+XhoCw6AAVQBENHftpXw9F4ryk66fTgYaKQ53R4FI7c9vUGGw5vQis1HKBHDR1gcYI/Bq1xvw==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -4357,21 +4372,31 @@
       }
     },
     "ts-node": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.1.0.tgz",
-      "integrity": "sha512-6szn3+J9WyG2hE+5W8e0ruZrzyk1uFLYye6IGMBadnOzDh8aP7t8CbFpsfCiEx2+wMixAhjFt7lOZC4+l+WbEA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.2.0.tgz",
+      "integrity": "sha512-FstYHtQz6isj8rBtYMN4bZdnXN1vq4HCbqn9vdNQcInRqtB86PePJQIxE6es0PhxKWhj2PHuwbG40H+bxkZPmg==",
       "dev": true,
       "requires": {
+        "@cspotcode/source-map-support": "0.6.1",
         "@tsconfig/node10": "^1.0.7",
         "@tsconfig/node12": "^1.0.7",
         "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.1",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
         "arg": "^4.1.0",
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
         "yn": "3.1.1"
+      },
+      "dependencies": {
+        "acorn-walk": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.1.1.tgz",
+          "integrity": "sha512-FbJdceMlPHEAWJOILDk1fXD8lnTlEIWFkqtfk+MvmL5q/qlHfN7GEHcsFZWt/Tea9jRNPWUZG4G976nqAAmU9w==",
+          "dev": true
+        }
       }
     },
     "type-check": {
@@ -4405,9 +4430,9 @@
       }
     },
     "typescript": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
     "union-value": {

--- a/expiring-value/package.json
+++ b/expiring-value/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sailplane/expiring-value",
-  "version": "1.0.2",
+  "version": "2.0.0",
   "description": "Container for a value that is instantiated on-demand (lazy-loaded via factory) and cached for a limited time.",
   "keywords": [
     "factory",
@@ -26,13 +26,13 @@
   ],
   "devDependencies": {
     "@types/jest": "^26.0.24",
-    "@types/node": "^10.17.60",
+    "@types/node": "^12.20.19",
     "jest": "^26.6.3",
     "mockdate": "^2.0.5",
     "ts-jest": "^26.5.6",
     "ts-loader": "^9.2.3",
-    "ts-node": "^10.1.0",
-    "typescript": "^2.9.2"
+    "ts-node": "^10.2.0",
+    "typescript": "3.8.x"
   },
   "main": "dist/expiring-value.js",
   "files": [

--- a/logger/package-lock.json
+++ b/logger/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@sailplane/logger",
-  "version": "2.0.4",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -443,6 +443,21 @@
         "minimist": "^1.2.0"
       }
     },
+    "@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "dev": true
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.6.1.tgz",
+      "integrity": "sha512-DX3Z+T5dt1ockmPdobJS/FAsQPW4V4SrWEhD2iYQT2Cb2tQsiMnYxrcUH9By/Z3B+v0S5LMBkQtV/XOBbpLEOg==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
@@ -697,9 +712,9 @@
       "dev": true
     },
     "@tsconfig/node16": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.1.tgz",
-      "integrity": "sha512-FTgBI767POY/lKNDNbIzgAX6miIDBs6NTCbdlDb8TrWovHsSvaVIZDlTqym29C6UqhzwcJx4CYr+AlrMywA0cA==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
     "@types/babel__core": {
@@ -787,9 +802,9 @@
       }
     },
     "@types/node": {
-      "version": "12.20.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.16.tgz",
-      "integrity": "sha512-6CLxw83vQf6DKqXxMPwl8qpF8I7THFZuIwLt4TnNsumxkp1VsRZWT8txQxncT/Rl2UojTsFzWgDG4FRMwafrlA==",
+      "version": "12.20.19",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.19.tgz",
+      "integrity": "sha512-niAuZrwrjKck4+XhoCw6AAVQBENHftpXw9F4ryk66fTgYaKQ53R4FI7c9vUGGw5vQis1HKBHDR1gcYI/Bq1xvw==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -4351,21 +4366,31 @@
       }
     },
     "ts-node": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.1.0.tgz",
-      "integrity": "sha512-6szn3+J9WyG2hE+5W8e0ruZrzyk1uFLYye6IGMBadnOzDh8aP7t8CbFpsfCiEx2+wMixAhjFt7lOZC4+l+WbEA==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.2.0.tgz",
+      "integrity": "sha512-FstYHtQz6isj8rBtYMN4bZdnXN1vq4HCbqn9vdNQcInRqtB86PePJQIxE6es0PhxKWhj2PHuwbG40H+bxkZPmg==",
       "dev": true,
       "requires": {
+        "@cspotcode/source-map-support": "0.6.1",
         "@tsconfig/node10": "^1.0.7",
         "@tsconfig/node12": "^1.0.7",
         "@tsconfig/node14": "^1.0.0",
-        "@tsconfig/node16": "^1.0.1",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
         "arg": "^4.1.0",
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
         "yn": "3.1.1"
+      },
+      "dependencies": {
+        "acorn-walk": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.1.1.tgz",
+          "integrity": "sha512-FbJdceMlPHEAWJOILDk1fXD8lnTlEIWFkqtfk+MvmL5q/qlHfN7GEHcsFZWt/Tea9jRNPWUZG4G976nqAAmU9w==",
+          "dev": true
+        }
       }
     },
     "type-check": {
@@ -4399,9 +4424,9 @@
       }
     },
     "typescript": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
+      "integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
       "dev": true
     },
     "union-value": {

--- a/logger/package.json
+++ b/logger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sailplane/logger",
-  "version": "2.0.4",
+  "version": "3.0.0",
   "description": "CloudWatch and serverless-offline friendly logger.",
   "keywords": [
     "aws",
@@ -27,12 +27,12 @@
   ],
   "devDependencies": {
     "@types/jest": "^26.0.24",
-    "@types/node": "^12.20.16",
+    "@types/node": "^12.20.19",
     "jest": "^26.6.3",
     "ts-jest": "^26.5.6",
     "ts-loader": "^9.2.3",
-    "ts-node": "^10.1.0",
-    "typescript": "^2.9.2"
+    "ts-node": "^10.2.0",
+    "typescript": "3.8.x"
   },
   "main": "dist/logger.js",
   "files": [


### PR DESCRIPTION
- Builds were failing due to new typing syntax of dependencies requiring Typescript v3+, not v2.
- Hopefully nobody is still running Typescript v2, but bumped major version of projects to reflect the new minimum dependency.

@ShaunEdiger @jbergdale-onica