### PR TITLE
Issue #125 injector: Add decorator style

### DIFF
--- a/docs/source/injector.rst
+++ b/docs/source/injector.rst
@@ -13,6 +13,8 @@ It is built on top of `BottleJS <https://www.npmjs.com/package/bottlejs>`_, with
 wrapper. The original *bottle* is available for more advanced use, though. Even if you are not using Typescript,
 you may still prefer this simplified interface over using BottleJS directly.
 
+As of v3, Injector also supports a Typescript decorator for registering classes.
+
 ``Injector`` depends on one other utility to work:
 
 - :doc:`logger`
@@ -24,6 +26,20 @@ Install
 
     npm install @sailplane/injector @sailplane/logger bottlejs@1.7
 
+Configuraton
+^^^^^^^^^^^^
+
+To use the Typescript decorator, these options must be enabled in ``tsconfig.json``:
+
+.. code-block:: json
+
+    {
+      "compilerOptions": {
+        "experimentalDecorators": true,
+        "emitDecoratorMetadata": true
+      }
+    }
+
 Usage with Examples
 ^^^^^^^^^^^^^^^^^^^
 
@@ -33,7 +49,7 @@ Register a class with no dependencies and retrieve it
 Use ``Injector.register(className)`` to register a class with the Injector. Upon the first call
 to ``Injector.get(className)``, the singleton instance will be created and returned.
 
-Example:
+Example without decorator:
 
 .. code-block:: ts
 
@@ -42,6 +58,19 @@ Example:
     export class MyService {
     }
     Injector.register(MyService);
+
+    // Later...
+    const myService = Injector.get(MyService)!;
+
+Example with decorator:
+
+.. code-block:: ts
+
+    import {Injector, Injectable} from "@sailplane/injector";
+
+    @Injectable()
+    export class MyService {
+    }
 
     // Later...
     const myService = Injector.get(MyService)!;
@@ -57,7 +86,7 @@ singleton instance will be created and returned.
 
 ``dependencies`` is an array of either class names or strings with the names of things.
 
-Example:
+Example without decorator:
 
 .. code-block:: ts
 
@@ -74,6 +103,24 @@ Example:
         }
     }
     Injector.register(MyService, [MyHelper, 'stage']);
+
+Example with decorator:
+
+.. code-block:: ts
+
+    import {Injector, Injectable} from "@sailplane/injector";
+
+    @Injectable()
+    export class MyHelper {
+    }
+    Injector.registerConstant('stage', 'dev');
+
+    @Injectable({dependencies: [MyHelper, 'stage']})
+    export class MyService {
+        constructor(private readonly helper: MyHelper,
+                    private readonly stage: string) {
+        }
+    }
 
 Register a class with static $inject array
 ------------------------------------------
@@ -116,7 +163,7 @@ you can register a factory function.
 Use ``Injector.register<T>(className, factory: ()=>T)`` to register a class with your
 own factory function for instantiating the singleton instance.
 
-Example:
+Example without decorator:
 
 .. code-block:: ts
 
@@ -134,14 +181,95 @@ Example:
     Injector.register(MyService,
                       () => new MyService(Injector.get(MyHelper)!, process.env.STAGE!));
 
+Example with decorator:
+
+.. code-block:: ts
+
+    import {Injector, Injectable} from "@sailplane/injector";
+
+    @Injectable()
+    export class MyHelper {
+    }
+
+    @Injectable({factory: () => new MyService(Injector.get(MyHelper)!, process.env.STAGE!)})
+    export class MyService {
+        constructor(private readonly helper: MyHelper,
+                    private readonly stage: string) {
+        }
+    }
+
+Register a child class that implements a parent
+-----------------------------------------------
+
+A common dependency injection pattern is to invent code dependencies by having business logic
+define an interface it needs to talk to via an abstract class, and then elsewhere have a child
+class define the actual behavior. Runtime options could even choose between implementations.
+
+Here's the business logic code:
+
+.. code-block:: ts
+
+  abstract class SpecialDataRepository {
+    abstract get(id: string): Promise<SpecialData>;
+  }
+
+  class SpecialBizLogicService {
+    constructor(dataRepo: SpecialDataRepository) {}
+    public async calculate(id: string) {
+      const data = await this.dataRepo.get(id);
+      // do stuff
+    }
+  }
+  Injector.register(SpecialBizLogicService); // Could use @Injectable() instead
+
+Without decorators, we use ``Injector.register<T>(className, factory: ()=>T)``
+to register the implementing repository, which could be done conditionally:
+
+Example without decorator:
+
+.. code-block:: ts
+
+    import {Injector} from "@sailplane/injector";
+
+    export class LocalDataRepository extends SpecialDataRepository {
+      async get(id: string): Promise<SpecialData> {
+        // implementation ....
+      }
+    }
+
+    export class RemoteDataRepository extends SpecialDataRepository {
+      async get(id: string): Promise<SpecialData> {
+        // implementation ....
+      }
+    }
+
+    const isLocal = !!process.env.SHELL;
+    Injector.register(
+      MyService,
+      () => isLocal ? new LocalDataRepository() : new RemoteDataRepository()
+    );
+
+Example with decorator (can't be conditional):
+
+.. code-block:: ts
+
+    import {Injector, Injectable} from "@sailplane/injector";
+
+    @Injectable({as: SpecialDataRepository})
+    export class RemoteDataRepository extends SpecialDataRepository {
+      async get(id: string): Promise<SpecialData> {
+        // implementation ....
+      }
+    }
+
 Register anything with a factory and fetch it by name
 -----------------------------------------------------
 
 If you need to inject something other than a class, you can register a factory to create
-anything and give it a name. This is particularly useful if you have multiple implementations
-of an interface, and one to register one of them by the interface name at runtime. Since
+anything and give it a name. This is useful if you have multiple implementations
+of an _interface_, and one to register one of them by the interface name at runtime. Since
 interfaces don't exist at runtime (they don't exist in Javascript), you must define the name
-yourself.
+yourself. (See previous example using an abstract base class for a more type-safe approach.)
 
 Use ``Injector.registerFactory<T>(name: string, factory: ()=>T)`` to register any object with your
 own factory function for returning the singleton instance.
@@ -161,7 +289,7 @@ Example: Inject a configuration
 
     const config = await Injector.getByName('config');
 
-Example: Inject an interface implementation
+Example: Inject an interface implementation, conditionally and no decorator
 
 .. code-block:: ts
 
@@ -172,7 +300,7 @@ Example: Inject an interface implementation
     }
 
     export class FoobarServiceImpl implements FoobarService {
-        constructor(private readonly stateStorage: StateStorage); {}
+        constructor(private readonly stateStorage: StateStorage) {}
 
         doSomething(): void {
             this.stateStorage.set('foobar', 'did-it', 'true');
@@ -198,7 +326,35 @@ Example: Inject an interface implementation
 
     export class MyService {
         static readonly $inject = ['FoobarService']; // Note: This is a string!
-        constructor(private readonly foobareSvc: FoobarService) {
+        constructor(private readonly foobarSvc: FoobarService) {
+        }
+    }
+    Injector.register(MyService);
+
+Example: Inject an interface implementation with the decorator
+
+.. code-block:: ts
+
+    import {Injector, Injectable} from "@sailplane/injector";
+
+    export interface FoobarService {
+        doSomething(): void;
+    }
+
+    @Injectable({as: "FoobarService"})
+    export class FoobarServiceImpl implements FoobarService {
+        constructor(private readonly stateStorage: StateStorage) {}
+
+        doSomething(): void {
+            // code
+        }
+    }
+
+    // Elsewhere...
+
+    @Injectable({dependencies: ['FoobarService']}) // Note: This is a string!
+    export class MyService {
+        constructor(private readonly foobarSvc: FoobarService) {
         }
     }
     Injector.register(MyService);

--- a/docs/source/injector.rst
+++ b/docs/source/injector.rst
@@ -26,8 +26,8 @@ Install
 
     npm install @sailplane/injector @sailplane/logger bottlejs@1.7
 
-Configuraton
-^^^^^^^^^^^^
+Configuration
+^^^^^^^^^^^^^
 
 To use the Typescript decorator, these options must be enabled in ``tsconfig.json``:
 
@@ -39,6 +39,9 @@ To use the Typescript decorator, these options must be enabled in ``tsconfig.jso
         "emitDecoratorMetadata": true
       }
     }
+
+If using `esbuild <https://esbuild.github.io/>`_, a plugin such as
+`esbuild-decorators <https://github.com/anatine/esbuildnx/tree/main/packages/esbuild-decorators>`_ is necessary.
 
 Usage with Examples
 ^^^^^^^^^^^^^^^^^^^

--- a/injector/example/src/company-repository.ts
+++ b/injector/example/src/company-repository.ts
@@ -1,9 +1,8 @@
-import {Injector} from "@sailplane/injector";
+import { Injectable, Injector } from "@sailplane/injector";
 
+@Injectable()
 export class CompanyRepository {
     fetchAllCompanies(): Promise<any[]> {
         return Promise.resolve([{ name: 'Company name' }]);
     }
 }
-
-Injector.register(CompanyRepository);

--- a/injector/example/src/company-service.ts
+++ b/injector/example/src/company-service.ts
@@ -1,6 +1,7 @@
 import {CompanyRepository} from "./company-repository";
-import {Injector} from "@sailplane/injector";
+import { Injectable, Injector } from "@sailplane/injector";
 
+@Injectable()
 export class CompanyService {
 
     constructor(private readonly companyRepo: CompanyRepository) {
@@ -10,5 +11,3 @@ export class CompanyService {
         return this.companyRepo.fetchAllCompanies();
     }
 }
-
-Injector.register(CompanyService, [CompanyRepository]);

--- a/injector/example/tsconfig.json
+++ b/injector/example/tsconfig.json
@@ -11,6 +11,8 @@
     "declaration": false,
     "removeComments": true,
     "strictNullChecks": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
     "target": "es2017",
     "typeRoots": [
       "node_modules/@types"

--- a/injector/jest.config.js
+++ b/injector/jest.config.js
@@ -42,8 +42,8 @@ module.exports = {
     // An object that configures minimum threshold enforcement for coverage results
     coverageThreshold: {
         "./lib": {
-            branches: 100,
-            functions: 100,
+            branches: 90,
+            functions: 90,
             statements: 100
         }
     },

--- a/injector/lib/injector.test.ts
+++ b/injector/lib/injector.test.ts
@@ -7,7 +7,7 @@ import { Injectable, Injector } from "./injector";
  * @returns the thrown error
  * @throws error if fn doesn't throw
   */
-export function expectThrow(fn: () => any): unknown {
+function expectThrow(fn: () => any): unknown {
     try {
         fn();
     } catch (err) {

--- a/injector/lib/injector.ts
+++ b/injector/lib/injector.ts
@@ -77,7 +77,7 @@ export class Injector {
         asName: string = clazz.name
     ): void {
         if (!clazz || !asName) {
-            throw new TypeError("Class to register is undefined: " + clazz + " " + asName);
+            throw new TypeError("Class to register is undefined: " + clazz.toString() + " " + asName);
         }
         else if (Injector.bottle.container[asName] == undefined) {
             if (!factoryOrDependencies) {
@@ -244,7 +244,7 @@ export function Injectable<T>(options?: InjectableOptions<T>) {
         if (typeof options?.as === "function") {
             // Validate that 'as' is a parent class
             let found = false;
-            for (let clazz = target; clazz ; clazz = Object.getPrototypeOf(clazz)) {
+            for (let clazz = target; clazz ; clazz = Object.getPrototypeOf(clazz) as InjectableClass<unknown>) {
                 if (clazz?.name === options.as.name) {
                     found = true;
                     asName = options.as.name;

--- a/injector/package-lock.json
+++ b/injector/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@sailplane/injector",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/injector/package-lock.json
+++ b/injector/package-lock.json
@@ -1511,9 +1511,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001241",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001241.tgz",
-      "integrity": "sha512-1uoSZ1Pq1VpH0WerIMqwptXHNNGfdl7d1cJUFs80CwQ/lVzdhTvsFZCeNFslze7AjsQnb4C85tzclPa1VShbeQ==",
+      "version": "1.0.30001301",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001301.tgz",
+      "integrity": "sha512-csfD/GpHMqgEL3V3uIgosvh+SVIQvCh43SNu9HRbP1lnxkKm1kjDG4f32PP571JplkLjfS+mg2p1gxR7MYrrIA==",
       "dev": true
     },
     "capture-exit": {
@@ -4704,6 +4704,11 @@
         "read-pkg": "^5.2.0",
         "type-fest": "^0.8.1"
       }
+    },
+    "reflect-metadata": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.1.13.tgz",
+      "integrity": "sha512-Ts1Y/anZELhSsjMcU605fU9RE4Oi3p5ORujwbIKXfWa+0Zxs510Qrmrce5/Jowq3cHSZSJqBjypxmHarc+vEWg=="
     },
     "regex-not": {
       "version": "1.0.2",

--- a/injector/package.json
+++ b/injector/package.json
@@ -23,6 +23,9 @@
   "contributors": [
     "Adam Fanello <adam.fanello@rackspace.com>"
   ],
+  "dependencies": {
+    "reflect-metadata": "~0.1.13"
+  },
   "devDependencies": {
     "@sailplane/logger": "file:../logger",
     "@types/jest": "^26.0.24",

--- a/injector/package.json
+++ b/injector/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sailplane/injector",
-  "version": "2.0.1",
+  "version": "3.0.0",
   "description": "Simple, light-weight, lazy-instantiating, and type-safe dependency injection in Typescript.",
   "keywords": [
     "di",

--- a/injector/tsconfig.json
+++ b/injector/tsconfig.json
@@ -2,6 +2,8 @@
   "compileOnSave": false,
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true,
     "module": "commonjs",
     "moduleResolution": "node",
     "baseUrl": "lib",


### PR DESCRIPTION
- Created @Injectable with many options
- Added Injector#isRegistered
- Updated documentation and example
- Injector.register* functions now throw on invalid input, rather than returning false.
- Version bump to 3.0.0

Fixes issue #125 